### PR TITLE
Rename `spacelift-db`to `spacelift`

### DIFF
--- a/.spacelift/config.yml
+++ b/.spacelift/config.yml
@@ -1,5 +1,5 @@
 version: 2
-module_version: "0.0.1"
+module_version: "0.0.2"
 
 tests:
   - name: Test infrastructure creation

--- a/modules/db/main.tf
+++ b/modules/db/main.tf
@@ -39,7 +39,7 @@ resource "google_sql_database_instance" "spacelift" {
 }
 
 resource "google_sql_database" "spacelift" {
-  name     = "spacelift-db"
+  name     = "spacelift"
   instance = google_sql_database_instance.spacelift.name
 }
 


### PR DESCRIPTION
I don't like the `-db` prefix for a database. Don't ask me why I did it initially.