### PR TITLE
chore: remove license token secret

### DIFF
--- a/.spacelift/config.yml
+++ b/.spacelift/config.yml
@@ -7,7 +7,6 @@ tests:
     environment:
       TF_VAR_region: europe-west3
       TF_VAR_project: self-hosted-v3-testing
-      TF_VAR_license_token: my-license-token
       TF_VAR_database_tier : db-f1-micro
       TF_VAR_website_domain: http://spacelift.mycorp.com
       TF_VAR_labels: '{"environment":"tf-module-testing"}'

--- a/README.md
+++ b/README.md
@@ -16,7 +16,6 @@ module "spacelift" {
 
   region         = "europe-west1"
   project        = "spacelift-production"
-  license_token  = "<token issued by Spacelift>"
   website_domain = "https://mycompany.spacelift.com"
   labels         = {"app" = "spacelift"}
 }
@@ -36,7 +35,6 @@ The module creates:
   - a Postgres Cloud SQL instance
 - Secret Manager resources
   - a secret for the root password of the Cloud SQL instance. Note that we recommend using passwordless authentication via [Cloud SQL Auth Proxy](https://cloud.google.com/sql/docs/mysql/connect-auth-proxy)
-  - a secret for the license token.
 - Storage resources
   - various buckets for storing run metadata, run logs, workspaces, stack states etc.
 
@@ -46,7 +44,6 @@ The module creates:
 | ------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ----------- | --------------------- | -------- |
 | region                          | The region in which the resources will be created.                                                                                                                                                                                                     | string      | -                     | yes      |
 | project                         | The ID of the project in which the resources will be created.                                                                                                                                                                                          | string      | -                     | yes      |
-| license_token                   | The license token issued by Spacelift.                                                                                                                                                                                                                 | string      | -                     | yes      |
 | website_domain                  | The domain under which the Spacelift instance will be hosted. This is used for the CORS rules of one of the buckets.                                                                                                                                   | string      | -                     | yes      |
 | labels                          | A map of labels to apply to all resources.                                                                                                                                                                                                             | map(string) | {}                    | no       |
 | k8s_namespace                   | The namespace in which the Spacelift backend service will be deployed.                                                                                                                                                                                 | string      | spacelift             | no       |
@@ -84,7 +81,6 @@ The module creates:
 | db_connection_name                    | Connection name of the database cluster. Needs to be passed to the Cloud SQL sidecar proxy. See the [official docs](https://cloud.google.com/sql/docs/mysql/connect-kubernetes-engine#proxy). |
 | db_dns_name                           | DNS name of the Cloud SQL instance.                                                                                                                                                           |
 | db_private_ip_address                 | Private IP address of the Cloud SQL instance.                                                                                                                                                 |
-| license_token_secret_id               | Secret ID of the license token.                                                                                                                                                               |
 | large_queue_messages_bucket           | Name of the bucket used for storing large queue messages.                                                                                                                                     |
 | metadata_bucket                       | Name of the bucket used for storing run metadata.                                                                                                                                             |
 | modules_bucket                        | Name of the bucket used for storing Spacelift modules.                                                                                                                                        |

--- a/main.tf
+++ b/main.tf
@@ -24,7 +24,6 @@ module "secrets" {
   depends_on = [module.iam]
 
   labels        = var.labels
-  license_token = var.license_token
   region        = var.region
 }
 

--- a/modules/secrets/main.tf
+++ b/modules/secrets/main.tf
@@ -12,14 +12,3 @@ resource "google_secret_manager_regional_secret_version" "secret-version-basic" 
   secret      = google_secret_manager_regional_secret.db-root-password.id
   secret_data = random_password.db-root-password.result
 }
-
-resource "google_secret_manager_regional_secret" "self-hosted-license" {
-  secret_id = "self-hosted-license"
-  location  = var.region
-  labels    = var.labels
-}
-
-resource "google_secret_manager_regional_secret_version" "self-hosted-license-secret-version-basic" {
-  secret      = google_secret_manager_regional_secret.self-hosted-license.id
-  secret_data = var.license_token
-}

--- a/modules/secrets/outputs.tf
+++ b/modules/secrets/outputs.tf
@@ -8,8 +8,3 @@ output "db_root_password_secret_id" {
   value       = google_secret_manager_regional_secret.db-root-password.id
   description = "ID of the secret containing the root password of the database."
 }
-
-output "license_token_secret_id" {
-  value       = google_secret_manager_regional_secret.self-hosted-license.id
-  description = "ID of the secret containing the license token."
-}

--- a/modules/secrets/variables.tf
+++ b/modules/secrets/variables.tf
@@ -1,8 +1,3 @@
-variable "license_token" {
-  description = "License token for the Self-Hosted instance"
-  sensitive   = true
-}
-
 variable "region" {
   type        = string
   description = "The region to create the secret in"

--- a/outputs.tf
+++ b/outputs.tf
@@ -112,11 +112,6 @@ output "db_root_password_secret_id" {
   description = "ID of the secret containing the root password of the database."
 }
 
-output "license_token_secret_id" {
-  value       = module.secrets.license_token_secret_id
-  description = "ID of the secret containing the license token."
-}
-
 ### Storage ###
 
 output "large_queue_messages_bucket" {
@@ -168,4 +163,3 @@ output "deliveries_bucket" {
   value       = module.storage.deliveries_bucket
   description = "Name of the bucket used for storing audit trail delivery data"
 }
-

--- a/variables.tf
+++ b/variables.tf
@@ -6,11 +6,6 @@ variable "project" {
   description = "Identifier of the GCP project to deploy the infrastructure into."
 }
 
-variable "license_token" {
-  description = "License token for the Self-Hosted instance."
-  sensitive   = true
-}
-
 variable "website_domain" {
   description = "Domain name for the Spacelift frontend with protocol (e.g. https://mycompany.spacelift.com). This is used as a CORS origin for the state uploads bucket."
 }


### PR DESCRIPTION
I'm not sure if we need to store the token in GCP, it just needs to be set in the k8s secret.
In our environment, we set it in GCP in order to retrieve it from CI, but that is specific to our environment.

I'm wondering if we should just remove it from here, because it can be misleading. Let's say a customer want to update their token because it's expiring, they will update this TF module inputs and apply.
They may think that this is good, but it's just a no-op. They'll have to fetch back this secret from secret manager and inject in back in their helm deployment.

That could make sense in the future to propose a setup where we use the external secret manager in GCP to manage them, but for now I'm tempted to keep it simple and remove it.

I'm planning to do the same for the DB root password, because we already have it in the state, WDYT?

