### PR TITLE
refactor: move db private IP in db module

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -44,7 +44,6 @@ module "db" {
   compute_network_id            = module.network.network_id
   database_deletion_protection  = var.database_deletion_protection
   database_edition              = var.database_edition
-  database_private_ip_name      = module.network.db_private_ip_name
   database_tier                 = var.database_tier
   network_link                  = module.network.network_link
   project                       = var.project

--- a/modules/db/iam.tf
+++ b/modules/db/iam.tf
@@ -39,7 +39,7 @@ resource "google_service_networking_connection" "private_vpc_connection" {
 
   network                 = var.compute_network_id
   service                 = "servicenetworking.googleapis.com"
-  reserved_peering_ranges = [var.database_private_ip_name]
+  reserved_peering_ranges = [google_compute_global_address.database-private-ip.name]
 
   # There is an annoying bug during 'terraform destroy' command where the peering connection
   # cannot be deleted sometimes due to an obscure error: https://github.com/hashicorp/terraform-provider-google/issues/16275

--- a/modules/db/networking.tf
+++ b/modules/db/networking.tf
@@ -1,0 +1,7 @@
+resource "google_compute_global_address" "database-private-ip" {
+  name          = "spacelift-database-private-ip"
+  purpose       = "VPC_PEERING"
+  address_type  = "INTERNAL"
+  prefix_length = 16
+  network       = var.compute_network_id
+}

--- a/modules/db/outputs.tf
+++ b/modules/db/outputs.tf
@@ -3,6 +3,11 @@ output "instance_name" {
   description = "Name of the database instance."
 }
 
+output "database_private_ip_address" {
+  value       = google_compute_global_address.database-private-ip.address
+  description = "Private IP address of the database instance."
+}
+
 output "database_name" {
   value       = google_sql_database.spacelift.name
   description = "Internal PostgreSQL db name inside the Cloud SQL instance."

--- a/modules/db/variables.tf
+++ b/modules/db/variables.tf
@@ -35,8 +35,3 @@ variable "compute_network_id" {
   type        = string
   description = "The ID of the network to which the database instance is connected"
 }
-
-variable "database_private_ip_name" {
-  type        = string
-  description = "The name of the private IP for the database instance"
-}

--- a/modules/network/main.tf
+++ b/modules/network/main.tf
@@ -4,15 +4,6 @@ resource "google_compute_network" "default" {
   enable_ula_internal_ipv6 = true
 }
 
-resource "google_compute_global_address" "database-private-ip" {
-  name          = "spacelift-database-private-ip"
-  purpose       = "VPC_PEERING"
-  address_type  = "INTERNAL"
-  prefix_length = 16
-  network       = google_compute_network.default.id
-  labels        = var.labels
-}
-
 # This public v4 address is meant to be used by Ingresses from the GKE cluster to expose services to the world.
 resource "google_compute_global_address" "gke-public-v4" {
   name         = "spacelift-gke-public-v4"

--- a/modules/network/outputs.tf
+++ b/modules/network/outputs.tf
@@ -22,8 +22,3 @@ output "gke_public_v6_address" {
   value       = google_compute_global_address.gke-public-v6.address
   description = "Public IPv6 address for GKE Ingresses"
 }
-
-output "db_private_ip_name" {
-  value       = google_compute_global_address.database-private-ip.name
-  description = "Name of the private IP address for the database"
-}

--- a/outputs.tf
+++ b/outputs.tf
@@ -91,8 +91,8 @@ output "db_connection_name" {
 }
 
 output "db_private_ip_address" {
-  value       = module.network.db_private_ip_name
-  description = "Private IP address of the database cluster"
+  value       = module.db.database_private_ip_address
+  description = "Private IP address of the database instance."
 }
 
 output "db_database_name" {


### PR DESCRIPTION
Just to follow the pattern that you did to group all resources types per module.