### PR TITLE
feat: add global seed param

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -1,3 +1,7 @@
+resource "random_id" "seed" {
+  byte_length = 4
+}
+
 module "iam" {
   source = "./modules/iam"
 
@@ -8,15 +12,18 @@ module "iam" {
 module "artifacts" {
   source     = "./modules/artifacts"
   depends_on = [module.iam]
+  seed = random_id.seed.hex
 }
 
 module "network" {
   source     = "./modules/network"
   depends_on = [module.iam]
+  seed = random_id.seed.hex
 }
 
 module "gke" {
   source = "./modules/gke"
+  seed = random_id.seed.hex
 
   app_service_account_name        = var.app_service_account_name
   backend_service_account_id      = module.iam.backend_service_account_id
@@ -34,6 +41,7 @@ module "gke" {
 
 module "db" {
   source = "./modules/db"
+  seed = random_id.seed.hex
 
   backend_service_account_email = module.iam.backend_service_account_email
   compute_network_id            = module.network.network_id
@@ -46,6 +54,7 @@ module "db" {
 
 module "storage" {
   source = "./modules/storage"
+  seed = random_id.seed.hex
 
   backend_service_account_email = module.iam.backend_service_account_email
   cors_origins                  = [var.website_domain]

--- a/modules/artifacts/main.tf
+++ b/modules/artifacts/main.tf
@@ -1,5 +1,5 @@
 resource "google_artifact_registry_repository" "spacelift" {
-  repository_id = "spacelift"
+  repository_id = "spacelift-${var.seed}"
   format        = "DOCKER"
   description   = "This repository contains the images for Spacelift"
 

--- a/modules/artifacts/variables.tf
+++ b/modules/artifacts/variables.tf
@@ -1,0 +1,3 @@
+variable "seed" {
+  type = string
+}

--- a/modules/db/main.tf
+++ b/modules/db/main.tf
@@ -1,7 +1,3 @@
-resource "random_id" "db_name_suffix" {
-  byte_length = 4
-}
-
 resource "random_password" "db-root-password" {
   length = 20
 }
@@ -9,7 +5,7 @@ resource "random_password" "db-root-password" {
 resource "google_sql_database_instance" "spacelift" {
   depends_on = [google_service_networking_connection.private_vpc_connection]
 
-  name             = "spacelift-${random_id.db_name_suffix.hex}"
+  name             = "spacelift-${var.seed}"
   database_version = "POSTGRES_14"
 
   # Please note that Spacelift application is authenticating passwordless via IAM,

--- a/modules/db/networking.tf
+++ b/modules/db/networking.tf
@@ -1,5 +1,5 @@
 resource "google_compute_global_address" "database-private-ip" {
-  name          = "spacelift-database-private-ip"
+  name          = "spacelift-database-private-ip-${var.seed}"
   purpose       = "VPC_PEERING"
   address_type  = "INTERNAL"
   prefix_length = 16

--- a/modules/db/variables.tf
+++ b/modules/db/variables.tf
@@ -35,3 +35,7 @@ variable "compute_network_id" {
   type        = string
   description = "The ID of the network to which the database instance is connected"
 }
+
+variable "seed" {
+  type = string
+}

--- a/modules/gke/main.tf
+++ b/modules/gke/main.tf
@@ -1,5 +1,5 @@
 resource "google_container_cluster" "spacelift" {
-  name = "spacelift"
+  name = "spacelift-${var.seed}"
 
   location                 = var.region
   enable_autopilot         = true

--- a/modules/gke/mqtt.tf
+++ b/modules/gke/mqtt.tf
@@ -1,7 +1,7 @@
 resource "google_compute_address" "gke-mqtt-v4" {
   count = var.create_compute_address_for_mqtt ? 1 : 0
 
-  name         = "gke-mqtt-v4"
+  name         = "gke-mqtt-v4-${var.seed}"
   address_type = "EXTERNAL"
   ip_version   = "IPV4"
 }
@@ -9,7 +9,7 @@ resource "google_compute_address" "gke-mqtt-v4" {
 resource "google_compute_address" "gke-mqtt-v6" {
   count = var.create_compute_address_for_mqtt ? 1 : 0
 
-  name               = "gke-mqtt-v6"
+  name               = "gke-mqtt-v6-${var.seed}"
   address_type       = "EXTERNAL"
   ip_version         = "IPV6"
   ipv6_endpoint_type = "NETLB"

--- a/modules/gke/network.tf
+++ b/modules/gke/network.tf
@@ -26,7 +26,7 @@ module "gke-router" {
   version = "~> 6.0"
   project = var.project
   region  = var.region
-  name    = "gke-router"
+  name    = "gke-router-${var.seed}"
 
   network = var.compute_network_name
   nats = [{

--- a/modules/gke/variables.tf
+++ b/modules/gke/variables.tf
@@ -57,3 +57,7 @@ variable "k8s_namespace" {
   type        = string
   description = "The namespace in which the Spacelift backend is deployed to"
 }
+
+variable "seed" {
+  type = string
+}

--- a/modules/network/main.tf
+++ b/modules/network/main.tf
@@ -6,14 +6,14 @@ resource "google_compute_network" "default" {
 
 # This public v4 address is meant to be used by Ingresses from the GKE cluster to expose services to the world.
 resource "google_compute_global_address" "gke-public-v4" {
-  name         = "spacelift-gke-public-v4"
+  name         = "spacelift-gke-public-v4-${var.seed}"
   address_type = "EXTERNAL"
   ip_version   = "IPV4"
 }
 
 # This public v6 address is meant to be used by Ingresses from the GKE cluster to expose services to the world.
 resource "google_compute_global_address" "gke-public-v6" {
-  name         = "spacelift-gke-public-v6"
+  name         = "spacelift-gke-public-v6-${var.seed}"
   address_type = "EXTERNAL"
   ip_version   = "IPV6"
 }

--- a/modules/network/variables.tf
+++ b/modules/network/variables.tf
@@ -1,0 +1,3 @@
+variable "seed" {
+  type = string
+}

--- a/modules/storage/main.tf
+++ b/modules/storage/main.tf
@@ -1,19 +1,15 @@
-resource "random_id" "unique-bucket-suffix" {
-  byte_length = 4
-}
-
 locals {
   bucket_names = {
-    "large-queue" : "spacelift-large-queue-messages-${random_id.unique-bucket-suffix.hex}",
-    "metadata" : "spacelift-metadata-${random_id.unique-bucket-suffix.hex}",
-    "modules" : "spacelift-modules-${random_id.unique-bucket-suffix.hex}",
-    "policy" : "spacelift-policy-inputs-${random_id.unique-bucket-suffix.hex}",
-    "run-logs" : "spacelift-run-logs-${random_id.unique-bucket-suffix.hex}",
-    "states" : "spacelift-states-${random_id.unique-bucket-suffix.hex}",
-    "uploads" : "spacelift-uploads-${random_id.unique-bucket-suffix.hex}",
-    "user-uploads" : "spacelift-user-uploaded-workspaces-${random_id.unique-bucket-suffix.hex}",
-    "workspace" : "spacelift-workspace-${random_id.unique-bucket-suffix.hex}",
-    "deliveries" : "spacelift-deliveries-${random_id.unique-bucket-suffix.hex}",
+    "large-queue" : "spacelift-large-queue-messages-${var.seed}",
+    "metadata" : "spacelift-metadata-${var.seed}",
+    "modules" : "spacelift-modules-${var.seed}",
+    "policy" : "spacelift-policy-inputs-${var.seed}",
+    "run-logs" : "spacelift-run-logs-${var.seed}",
+    "states" : "spacelift-states-${var.seed}",
+    "uploads" : "spacelift-uploads-${var.seed}",
+    "user-uploads" : "spacelift-user-uploaded-workspaces-${var.seed}",
+    "workspace" : "spacelift-workspace-${var.seed}",
+    "deliveries" : "spacelift-deliveries-${var.seed}",
   }
 }
 

--- a/modules/storage/variable.tf
+++ b/modules/storage/variable.tf
@@ -17,3 +17,7 @@ variable "cors_origins" {
   type        = list(string)
   description = "List of allowed origins for CORS. This is being used for state uploads during Stack creations. Example: [\"https://spacelift.mycorp.com\"]"
 }
+
+variable "seed" {
+  type = string
+}


### PR DESCRIPTION
Some resources like google_compute_network are global and can conflict. We are already using random ids for db abd bucket names, so I moved to use a global random seed for all resources instead for a better consistency.