### PR TITLE
feat: remove scheme from `website_domain`

### DIFF
--- a/.spacelift/config.yml
+++ b/.spacelift/config.yml
@@ -8,6 +8,6 @@ tests:
       TF_VAR_region: europe-west3
       TF_VAR_project: self-hosted-v3-testing
       TF_VAR_database_tier : db-f1-micro
-      TF_VAR_website_domain: http://spacelift.mycorp.com
+      TF_VAR_website_domain: spacelift.mycorp.com
       TF_VAR_labels: '{"environment":"tf-module-testing"}'
       TF_VAR_database_deletion_protection: false

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ module "spacelift" {
 
   region         = "europe-west1"
   project        = "spacelift-production"
-  website_domain = "https://mycompany.spacelift.com"
+  website_domain = "spacelift.mycompany.com"
   labels         = {"app" = "spacelift"}
 }
 ```

--- a/main.tf
+++ b/main.tf
@@ -57,7 +57,7 @@ module "storage" {
   seed = random_id.seed.hex
 
   backend_service_account_email = module.iam.backend_service_account_email
-  cors_origins                  = [var.website_domain]
+  cors_origins                  = ["https://${var.website_domain}"]
   project                       = var.project
   region                        = var.region
 }

--- a/variables.tf
+++ b/variables.tf
@@ -7,7 +7,7 @@ variable "project" {
 }
 
 variable "website_domain" {
-  description = "Domain name for the Spacelift frontend with protocol (e.g. https://mycompany.spacelift.com). This is used as a CORS origin for the state uploads bucket."
+  description = "Domain name for the Spacelift frontend without protocol (e.g. spacelift.mycompany.com). This is used as a CORS origin for the state uploads bucket."
 }
 
 variable "labels" {


### PR DESCRIPTION
We need to be able to have only the domain as output, so let's just ask the domain without scheme as input and interpolate with https. Asking the scheme does not make sense since spacelift is only meant to be run under https.