### PR TITLE
fix: remove quotes in shell output

### DIFF
--- a/env.tftpl
+++ b/env.tftpl
@@ -1,3 +1,3 @@
 %{ for key, value in env }
-export ${key}="${value}"
+export ${key}=${value}
 %{~ endfor }


### PR DESCRIPTION
quotes are also exportedin the vars values, that causes issues if you follow the guide.