### PR TITLE
fix: deps on delete

### DIFF
--- a/modules/db/main.tf
+++ b/modules/db/main.tf
@@ -41,6 +41,7 @@ resource "google_sql_database_instance" "spacelift" {
 resource "google_sql_database" "spacelift" {
   name     = "spacelift"
   instance = google_sql_database_instance.spacelift.name
+  depends_on = [google_sql_user.spacelift-backend-iam-user]
 }
 
 resource "google_sql_user" "spacelift-backend-iam-user" {


### PR DESCRIPTION
Fix the following error when destroying

```
Error: Error, failed to deleteuser
spacelift-backend@self-hosted-v3-testing.iam in instance
spacelift-e03ef1c2: googleapi: Error 400: Invalid request: failed to
delete user spacelift-backend@self-hosted-v3-testing.iam: . role
"spacelift-backend@self-hosted-v3-testing.iam" cannot be dropped because
some objects depend on it Details: privileges for database spacelift│
261 objects in database spacelift., invalid
```