### PR TITLE
fix: enable force destroy for buckets

### DIFF
--- a/modules/storage/main.tf
+++ b/modules/storage/main.tf
@@ -16,6 +16,7 @@ locals {
 resource "google_storage_bucket" "spacelift-large-queue-messages" {
   name     = local.bucket_names["large-queue"]
   location = var.region
+  force_destroy = true
 
   public_access_prevention = "enforced"
 
@@ -40,6 +41,7 @@ resource "google_storage_bucket" "spacelift-large-queue-messages" {
 resource "google_storage_bucket" "spacelift-metadata" {
   name     = local.bucket_names["metadata"]
   location = var.region
+  force_destroy = true
 
   public_access_prevention = "enforced"
 
@@ -65,6 +67,7 @@ resource "google_storage_bucket" "spacelift-metadata" {
 resource "google_storage_bucket" "spacelift-modules" {
   name     = local.bucket_names["modules"]
   location = var.region
+  force_destroy = true
 
   versioning {
     enabled = true
@@ -76,6 +79,7 @@ resource "google_storage_bucket" "spacelift-modules" {
 resource "google_storage_bucket" "spacelift-policy-inputs" {
   name     = local.bucket_names["policy"]
   location = var.region
+  force_destroy = true
 
   public_access_prevention = "enforced"
 
@@ -96,6 +100,7 @@ resource "google_storage_bucket" "spacelift-policy-inputs" {
 resource "google_storage_bucket" "spacelift-run-logs" {
   name     = local.bucket_names["run-logs"]
   location = var.region
+  force_destroy = true
 
   public_access_prevention = "enforced"
 
@@ -135,6 +140,7 @@ resource "google_storage_bucket" "spacelift-run-logs" {
 resource "google_storage_bucket" "spacelift-states" {
   name     = local.bucket_names["states"]
   location = var.region
+  force_destroy = true
 
   versioning {
     enabled = true
@@ -165,6 +171,7 @@ resource "google_storage_bucket" "spacelift-states" {
 resource "google_storage_bucket" "spacelift-uploads" {
   name     = local.bucket_names["uploads"]
   location = var.region
+  force_destroy = true
 
   public_access_prevention = "enforced"
 
@@ -210,6 +217,7 @@ resource "google_storage_bucket" "spacelift-uploads" {
 resource "google_storage_bucket" "spacelift-user-uploaded-workspaces" {
   name     = local.bucket_names["user-uploads"]
   location = var.region
+  force_destroy = true
 
   public_access_prevention = "enforced"
 
@@ -249,6 +257,7 @@ resource "google_storage_bucket" "spacelift-user-uploaded-workspaces" {
 resource "google_storage_bucket" "spacelift-workspace" {
   name     = local.bucket_names["workspace"]
   location = var.region
+  force_destroy = true
 
   public_access_prevention = "enforced"
 
@@ -288,6 +297,7 @@ resource "google_storage_bucket" "spacelift-workspace" {
 resource "google_storage_bucket" "spacelift-deliveries" {
   name     = local.bucket_names["deliveries"]
   location = var.region
+  force_destroy = true
 
   public_access_prevention = "enforced"
 


### PR DESCRIPTION
Allows to remove buckets even if not empty. Otherwise `tofu destroy` does not works.