### PR TITLE
Remove trailing slash from Artifact domain

### DIFF
--- a/modules/artifacts/outputs.tf
+++ b/modules/artifacts/outputs.tf
@@ -1,5 +1,5 @@
 output "repository_domain" {
-  value       = "${google_artifact_registry_repository.spacelift.location}-docker.pkg.dev/"
+  value       = "${google_artifact_registry_repository.spacelift.location}-docker.pkg.dev"
   description = "The domain of the Docker repository"
 }
 


### PR DESCRIPTION
<img width="849" alt="image" src="https://github.com/user-attachments/assets/598ab289-f383-40b7-a5ac-6bc7ebb3d515" />

--

After removing the trailing slash:

<img width="815" alt="image" src="https://github.com/user-attachments/assets/6621f3ad-4f65-4595-a068-7fe1850d2082" />

