### PR TITLE
fix: invalid local vars

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -3,8 +3,8 @@ resource "random_id" "seed" {
 }
 
 locals {
-  network                   = var.enable_network ? module.network.network : var.network
-  subnetwork                = var.enable_network ? module.network.subnetwork : var.subnetwork
+  network                   = [module.network.network, var.network][var.enable_network ? 0 : 1]
+  subnetwork                = [module.network.subnetwork, var.subnetwork][var.enable_network ? 0 : 1]
   gke_service_account_email = var.enable_gke ? module.iam.gke_service_account_email : var.node_service_account.email
 }
 


### PR DESCRIPTION
This fixes an issue where Terraform complains because the default of network and subnetwork is `null`.

See https://spacelift-io.app.spacelift.io/module/terraform-google-spacelift-selfhosted/run/01JH2SJSAPHDNZ01NRM3T5T7CS

```
│ Error: Inconsistent conditional result types
│
│   on .terraform/modules/spacelift/main.tf line 6, in locals:
│    6:   network                   = var.enable_network ? module.network.network : var.network
│     ├────────────────
│     │ module.network.network is object with 16 attributes
│     │ var.enable_network is true
│     │ var.network is null
│
│ The true and false result expressions must have consistent types. The 'true' value includes object attribute "auto_create_subnetworks", which is absent in the 'false' value.
```

![2025-01-13_15-20](https://github.com/user-attachments/assets/162049aa-8e73-4fac-867a-494dff55286d)


The hack here is to transform those to a tuple and use the ternary operator to set the proper tuple index to use.

I'm not sure why I did not catched that while working on it back in December ...