### PR TITLE
fix: wrong mqtt endpoint host

### DIFF
--- a/modules/dns/outputs.tf
+++ b/modules/dns/outputs.tf
@@ -1,4 +1,4 @@
 output "mqtt_endpoint" {
-  value       = var.enable_external_workers ? trimsuffix(google_dns_record_set.CNAME_mqtt[0].name, ".") : local.mqtt_service_alias
+  value       = var.enable_external_workers ? trimsuffix(google_dns_record_set.CNAME_mqtt[0].name, ".") : trimsuffix(local.mqtt_service_alias, ".")
   description = "Address of the MQTT endpoint."
 }


### PR DESCRIPTION
When don't use external workers, the mqtt endpoint is set to be the internal DNS alias (svc.namespace.svc.cluster.local.) with a trailing dot.
When injected into the `tls://` URL it's not correct, we need to also remove the trailing dot.
Otherwise we could end with the following incorrect config

```yaml
MQTT_BROKER_ENDPOINT: "tls://spacelift-mqtt.spacelift.svc.cluster.local.:1984"
```