### PR TITLE
fix: remove google provider config from module

### DIFF
--- a/.spacelift/config.yml
+++ b/.spacelift/config.yml
@@ -1,13 +1,10 @@
 version: 2
-module_version: "0.0.7"
+module_version: "0.0.8"
 
 tests:
   - name: Test infrastructure creation
     runner_image: public.ecr.aws/spacelift/runner-terraform:gcp-latest
+    project_root: "examples/simple"
     environment:
       TF_VAR_region: europe-west3
       TF_VAR_project: self-hosted-v3-testing
-      TF_VAR_database_tier : db-f1-micro
-      TF_VAR_website_domain: spacelift.mycorp.com
-      TF_VAR_labels: '{"environment":"tf-module-testing"}'
-      TF_VAR_database_deletion_protection: false

--- a/README.md
+++ b/README.md
@@ -17,7 +17,6 @@ module "spacelift" {
   region         = "europe-west1"
   project        = "spacelift-production"
   website_domain = "spacelift.mycompany.com"
-  labels         = {"app" = "spacelift"}
 }
 ```
 
@@ -57,7 +56,6 @@ module "spacelift" {
   project        = var.project
   website_domain = var.app_domain
   database_tier  = "db-f1-micro"
-  labels         = {"app" = "spacelift"}
 }
 ```
 

--- a/examples/simple/main.tf
+++ b/examples/simple/main.tf
@@ -1,0 +1,40 @@
+terraform {
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = "~> 6.0"
+    }
+
+    random = {
+      source  = "hashicorp/random"
+      version = "~> 3.0"
+    }
+  }
+}
+
+variable "region" {
+  description = "Identifier of the GCP region to deploy the infrasturcure into."
+}
+
+variable "project" {
+  description = "Identifier of the GCP project to deploy the infrastructure into."
+}
+
+provider "google" {
+  region  = var.region
+  project = var.project
+
+  default_labels = {
+    "environment" = "tf-module-testing"
+  }
+}
+
+module "spacelift" {
+  source = "../.."
+
+  region                       = var.region
+  project                      = var.project
+  website_domain               = "spacelift.mycorp.com"
+  database_tier                = "db-f1-micro"
+  database_deletion_protection = false
+}

--- a/provider.tf
+++ b/provider.tf
@@ -11,9 +11,3 @@ terraform {
     }
   }
 }
-
-provider "google" {
-  region         = var.region
-  project        = var.project
-  default_labels = var.labels
-}

--- a/variables.tf
+++ b/variables.tf
@@ -10,12 +10,6 @@ variable "website_domain" {
   description = "Domain name for the Spacelift frontend without protocol (e.g. spacelift.mycompany.com). This is used as a CORS origin for the state uploads bucket."
 }
 
-variable "labels" {
-  type        = map(string)
-  description = "Map of labels to apply to the resources"
-  default     = {}
-}
-
 variable "k8s_namespace" {
   type        = string
   description = "The namespace in which the Spacelift backend is deployed to"


### PR DESCRIPTION
I've removed the google provider configuration block from the module so that module consumers can set this themselves.

I've left the `region` and `project` variables because they are used by other parts of the module, but removed the `labels` variable since it's only used for provider configuration.

I've also added a separate test case in an `examples` folder so that we can configure the provider correctly in the test case.