### PR TITLE
fix: add missing db conn name env var

### DIFF
--- a/outputs.tf
+++ b/outputs.tf
@@ -179,9 +179,10 @@ output "shell" {
       LAUNCHER_IMAGE : "${module.artifacts.launcher_repository_url}/spacelift-launcher"
 
       # Database
-      DATABASE_NAME    = var.enable_database ? module.db[0].database_name : ""
-      DATABASE_USER    = var.enable_database ? module.db[0].database_iam_user : ""
-      DB_ROOT_PASSWORD = var.enable_database ? module.db[0].database_root_password : ""
+      DATABASE_NAME            = var.enable_database ? module.db[0].database_name : ""
+      DATABASE_USER            = var.enable_database ? module.db[0].database_iam_user : ""
+      DB_ROOT_PASSWORD         = var.enable_database ? module.db[0].database_root_password : ""
+      DATABASE_CONNECTION_NAME = var.enable_database ? module.db[0].database_connection_name : ""
 
       #GKE
       GKE_CLUSTER_NAME = module.gke.gke_cluster_name


### PR DESCRIPTION
I think it was removed by mistake, we need it in the setup db script: 
https://user-documentation-shv3.onrender.com/self-hosted/latest/installing-spacelift/reference-architecture/guides/deploying-to-gke.html#configure-database