### PR TITLE
refactor: collapse count-gated network outputs to one()

### DIFF
--- a/modules/network/outputs.tf
+++ b/modules/network/outputs.tf
@@ -1,9 +1,9 @@
 output "subnetwork" {
-  value = length(google_compute_subnetwork.default) == 1 ? google_compute_subnetwork.default[0] : null
+  value = one(google_compute_subnetwork.default)
 }
 
 output "network" {
-  value = length(google_compute_network.default) == 1 ? google_compute_network.default[0] : null
+  value = one(google_compute_network.default)
 }
 
 output "gke_public_v4_address" {


### PR DESCRIPTION
Terraform's `one()` does exactly that for a 0-or-1 element list, so the condition can't drift out of sync with the resource's actual `count`.